### PR TITLE
Added base extended latin characters to Main fonts

### DIFF
--- a/fonts/OTF/TeX/makeFF
+++ b/fonts/OTF/TeX/makeFF
@@ -66,6 +66,13 @@ $map{cmr10} = {
     0x7E => [0x303,-500,0], # \tilde (combining)
     0x7F => 0xA8,           # \ddot
     0x7F => [0x308,-500,0], # \ddot (combining)
+    0x19 => 0xDF,           # sharp S
+    0x1A => 0xE6,           # ae ligature
+    0x1B => 0x153,          # oe ligature
+    0x1C => 0xF8,           # o with slash
+    0x1D => 0xC6,           # AE ligature
+    0x1E => 0x152,          # OE ligature
+    0x1F => 0xD8,           # O with slash         
   ],
 
   "Greek" => [
@@ -632,6 +639,13 @@ $map{cmti10} = {
     0x7E => [0x7E,0,-350],  # ~
     0x7E => [0x303,-511,0], # \tilde (combining)
     0x7F => [0x308,-511,0], # \ddot (combining)
+    0x19 => 0xDF,           # sharp S
+    0x1A => 0xE6,           # ae ligature
+    0x1B => 0x153,          # oe ligature
+    0x1C => 0xF8,           # o with slash
+    0x1D => 0xC6,           # AE ligature
+    0x1E => 0x152,          # OE ligature
+    0x1F => 0xD8,           # O with slash       
   ],
 
   "WinChrome" => [
@@ -694,6 +708,13 @@ $map{cmbx10} = {
     0x7E => [0x303,-575,0], # \tilde (combining)
     0x7F => 0xA8,           # \ddot
     0x7F => [0x308,-575,0], # \ddot (combining)
+    0x19 => 0xDF,           # sharp S
+    0x1A => 0xE6,           # ae ligature
+    0x1B => 0x153,          # oe ligature
+    0x1C => 0xF8,           # o with slash
+    0x1D => 0xC6,           # AE ligature
+    0x1E => 0x152,          # OE ligature
+    0x1F => 0xD8,           # O with slash       
   ],
 
   "Greek-Bold" => [


### PR DESCRIPTION
We'd like to support rendering extended latin characters in
order to support rendering text from European languages within
\text{}.  Adding the base characters to Main-Regular, Main-Italic,
and Main-Bold, is the first step in doing so.  Eventually we'll
need a way to compose accented characted from unicode text, but
that will follow in a later diff.

Test Plan:
- run `make ttf eot woff woff2` in the MathJaxFonts docker image in KaTeX
- copy the font files out of the docker, open them up on Font Book and verify that they have the correct glyphs at the correct unicode code points

Reviewers: emily
